### PR TITLE
Improve interaction with popup window

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Additional options are:
 
 Tries to authenticate. Calls callback if successful.
 
+`.bringPopupWindowToFront()`
+
+Tries to bring an existing authentication popup to the front. Returns `true` on success or `false` if there is no
+authentication popup or if it couldn't be brought to the front (e.g. because of cross-origin restrictions).
+
 `.xhr(options, callback)`
 
 Signed [XMLHttpRequest](http://en.wikipedia.org/wiki/XMLHttpRequest).

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,11 @@ declare namespace OSMAuth {
     }
 
     interface OSMAuthInstance {
+        popupWindow?: Window
         logout(): OSMAuthInstance;
         authenticated(): boolean;
         authenticate(callback: (error: null | ErrorEvent | XMLHttpRequest, oauth?: OSMAuthInstance) => any): any;
+        bringPopupWindowToFront(): boolean;
         xhr(options: OSMAuthXHROptions, callback: (error: null | ErrorEvent | XMLHttpRequest, xhr: any) => any): any;
         options(): OSMAuthOptions;
         options(options: OSMAuthNewOptions): OSMAuthInstance;

--- a/index.html
+++ b/index.html
@@ -78,9 +78,11 @@
         }
 
         document.getElementById('authenticate').onclick = function() {
-            auth.authenticate(function() {
-                update();
-            });
+            if (!auth.bringPopupWindowToFront()) {
+                auth.authenticate(function() {
+                    update();
+                });
+            }
         };
 
         function showDetails() {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ module.exports = function(o) {
                         return x.join('=');
                     }).join(','),
                 popup = window.open('about:blank', 'oauth_window', settings);
+
+            oauth.popupWindow = popup
         }
 
         // Request a request token. When this is complete, the popup
@@ -114,6 +116,20 @@ module.exports = function(o) {
             token('oauth_token_secret', access_token.oauth_token_secret);
             callback(null, oauth);
         }
+    };
+
+    oauth.bringPopupWindowToFront = function() {
+        var brougtPopupToFront = false;
+        try {
+            // This may cause a cross-origin error:
+            // `DOMException: Blocked a frame with origin "..." from accessing a cross-origin frame.`
+            if (oauth.popupWindow && !oauth.popupWindow.closed) {
+                oauth.popupWindow.focus();
+                brougtPopupToFront = true;
+            }
+        } catch (err) {
+        }
+        return brougtPopupToFront;
     };
 
     oauth.bootstrapToken = function(oauth_token, callback) {

--- a/index.js
+++ b/index.js
@@ -53,12 +53,12 @@ module.exports = function(o) {
                     }).join(','),
                 popup = window.open('about:blank', 'oauth_window', settings);
 
-            oauth.popupWindow = popup
+            oauth.popupWindow = popup;
 
             if (!popup) {
-                var error = new Error('Popup was blocked')
-                error.status = 'popup-blocked'
-                throw error
+                var error = new Error('Popup was blocked');
+                error.status = 'popup-blocked';
+                throw error;
             }
         }
 
@@ -134,6 +134,7 @@ module.exports = function(o) {
                 brougtPopupToFront = true;
             }
         } catch (err) {
+            // Bringing popup window to front failed (probably because of the cross-origin error mentioned above)
         }
         return brougtPopupToFront;
     };

--- a/index.js
+++ b/index.js
@@ -54,6 +54,12 @@ module.exports = function(o) {
                 popup = window.open('about:blank', 'oauth_window', settings);
 
             oauth.popupWindow = popup
+
+            if (!popup) {
+                var error = new Error('Popup was blocked')
+                error.status = 'popup-blocked'
+                throw error
+            }
         }
 
         // Request a request token. When this is complete, the popup


### PR DESCRIPTION
This adds the function `bringPopupWindowToFront()` which tries to bring an existing popup window to the front. This is helpful if the user accidentally moved the popup behind other windows (e.g. by clicking on the main app's window).

Furthermore now an exception is thrown if the popup was blocked by the browser. Without this, osm-auth will never inform the caller of `authenticate` that something went wrong, so the calling app will wait forever for the login. The error is flagged with `status = 'popup-blocked'` so the app can detect this case and can show a button for trying again. And if `authenticate` is then called within the button's click handler, the browser won't block the popup any more.