### PR TITLE
Single page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,34 @@ document.getElementById("authenticate").onclick = function () {
 ```
 
 ### Example with single-page
-coming soon
+```js
+var redirectPath = window.location.origin + window.location.pathname;
+var auth = osmAuth.osmAuth({
+  client_id: "JWXSAzNp64sIRMStTnkhMRaMxSR964V4sFgn3KUZNTA",
+  client_secret: "6umOXfkZqH5CVUtv6iDqN7k8o7mKbQvTrHvbDQH36hs",
+  redirect_uri: redirectPath,
+  scope: "read_prefs",
+  auto: true  // show a login form if the user is not authenticated and you try to do a call
+  singlepage: true,
+});
+
+document.getElementById("authenticate").onclick = function () {
+  // Signed method call - since `auto` is true above, this will
+  // automatically start an authentication process if the user isn't
+  // authenticated yet.
+  auth.xhr({ method: "GET", path: "/api/0.6/user/details" },
+    function (err, result) {
+      // result is an XML DOM containing the user details
+    }
+  );
+};
+
+if (window.location.search.includes('code')) {
+  auth.authenticate(function() {
+    // Fully authed at this point
+  });
+}
+```
 
 # API
 

--- a/src/osm-auth.mjs
+++ b/src/osm-auth.mjs
@@ -75,7 +75,14 @@ export function osmAuth(o) {
         scope: o.scope,
       });
 
-    if (!o.singlepage) {
+    if (o.singlepage) {
+      var params = utilStringQs(window.location.search.slice(1));
+      if (params.code) {
+        getAccessToken(params.code);
+      } else {
+        window.location = url;
+      }
+    } else {
       // Create a 600x550 popup window in the center of the screen
       var w = 600;
       var h = 550;


### PR DESCRIPTION
I found myself needing the unimplemented single page authentication, so I've added it.

`authenticate` will now redirect if `singlepage==true` and if `code` is set, it will use it.

Includes an example of how to to use it.

for a demo check out my fork's github pages deployment: https://dschep.github.io/osm-auth/

I'd be happy to add that change or something like it to this PR if the maintainers can add the right URLs to the OAuth2 app.