### PR TITLE
changelog: clarify changes to singlepage mode in v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _Breaking changes, which may affect downstream projects, are marked with a_ тЪая
 ## 2.1.0
 ##### 2023-May-17
 * Add fetch wrapper ([#112], thanks [@dschep])
-* Fix singlepage authentication support ([#113], thanks [@dschep])
+* Simlify and document singlepage authentication ([#113], thanks [@dschep])
 
 [#112]: https://github.com/osmlab/osm-auth/issues/112
 [#113]: https://github.com/osmlab/osm-auth/issues/113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _Breaking changes, which may affect downstream projects, are marked with a_ тЪая
 ## 2.1.0
 ##### 2023-May-17
 * Add fetch wrapper ([#112], thanks [@dschep])
-* Simlify and document singlepage authentication ([#113], thanks [@dschep])
+* Simplify and document singlepage authentication ([#113], thanks [@dschep])
 
 [#112]: https://github.com/osmlab/osm-auth/issues/112
 [#113]: https://github.com/osmlab/osm-auth/issues/113


### PR DESCRIPTION
Singlepage mode was not broken before v2.1.0, so the current description is not quite right. The version just adds a simplified method to implement the mode and documents it in the readme using an example.

see https://github.com/osmlab/osm-auth/pull/113#issuecomment-1627603699