### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ var redirectPath = window.location.origin + window.location.pathname;
 Additional options are:
 
  - `access_token` - Can pre-authorize with an OAuth2 bearer token if you have one
- - `url` - A base url (default: "https://www.openstreetmap.org")
+ - `url` - A base url (default: "https://api.openstreetmap.org")
  - `auto` - If `true`, attempt to authenticate automatically when calling `.xhr()` or `fetch()` (default: `false`)
  - `singlepage` - If `true`, use page redirection instead of a popup (default: `false`)
  - `loading` - Function called when auth-related xhr calls start

--- a/src/osm-auth.mjs
+++ b/src/osm-auth.mjs
@@ -11,7 +11,7 @@ import store from 'store';
  * @param    o.client_id      OAuth2 client ID
  * @param    o.redirect_uri   OAuth2 redirect URI (e.g. "http://127.0.0.1:8080/land.html")
  * @param    o.access_token   Can pre-authorize with an OAuth2 bearer token if you have one
- * @param    o.url            A base url (default: "https://www.openstreetmap.org")
+ * @param    o.url            A base url (default: "https://api.openstreetmap.org")
  * @param    o.auto           If `true`, attempt to authenticate automatically when calling `.xhr()` or `.fetch()` (default: `false`)
  * @param    o.singlepage     If `true`, use page redirection instead of a popup (default: `false`)
  * @param    o.loading        Function called when auth-related xhr calls start
@@ -428,7 +428,7 @@ export function osmAuth(o) {
     if (!arguments.length) return o;
 
     o = val;
-    o.url = o.url || 'https://www.openstreetmap.org';
+    o.url = o.url || 'https://api.openstreetmap.org';
     o.auto = o.auto || false;
     o.singlepage = o.singlepage || false;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,7 @@ test('osmauth', t => {
     t.test('gets and sets new options', t => {
       localStorage.clear();
       const keys = {
-        url: 'https://www.openstreetmap.org',
+        url: 'https://api.openstreetmap.org',
         client_id: 'JWXSAzNp64sIRMStTnkhMRaMxSR964V4sFgn3KUZNTA',
         client_secret: '6umOXfkZqH5CVUtv6iDqN7k8o7mKbQvTrHvbDQH36hs',
         redirect_uri: 'http://127.0.0.1:8080/land.html',
@@ -31,7 +31,7 @@ test('osmauth', t => {
     t.test('is not initially authorized', t => {
       localStorage.clear();
       const auth = osmAuth({
-        url: 'https://www.openstreetmap.org',
+        url: 'https://api.openstreetmap.org',
         client_id: 'JWXSAzNp64sIRMStTnkhMRaMxSR964V4sFgn3KUZNTA',
         redirect_uri: 'http://127.0.0.1:8080/land.html',
         scope: 'read_prefs'
@@ -43,7 +43,7 @@ test('osmauth', t => {
     t.test('can be preauthorized', t => {
       localStorage.clear();
       const auth = osmAuth({
-        url: 'https://www.openstreetmap.org',
+        url: 'https://api.openstreetmap.org',
         client_id: 'JWXSAzNp64sIRMStTnkhMRaMxSR964V4sFgn3KUZNTA',
         redirect_uri: 'http://127.0.0.1:8080/land.html',
         scope: 'read_prefs',


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

Except for regular link in [index.html](https://github.com/osmlab/osm-auth/blob/4a608f2dfb6a15a15cc7a19d2668f5bca944ee03/index.html#L112).

_PR will initially be marked as a draft, as there seem to be unresolved issues upstream._