### PR TITLE
allow the locale of the login page to be set

### DIFF
--- a/src/osm-auth.d.ts
+++ b/src/osm-auth.d.ts
@@ -28,6 +28,7 @@ declare namespace OSMAuth {
     singlepage?: boolean;
     loading?: () => any;
     done?: () => any;
+    locale?: string;
   }
 
   interface OSMAuthFetchOptions {

--- a/src/osm-auth.mjs
+++ b/src/osm-auth.mjs
@@ -15,6 +15,7 @@
  * @param    o.singlepage     If `true`, use page redirection instead of a popup (default: `false`)
  * @param    o.loading        Function called when auth-related xhr calls start
  * @param    o.done           Function called when auth-related xhr calls end
+ * @param    o.locale         The locale to use on the OAuth2 authentication page. Optional.
  * @return  `self`
  */
 export function osmAuth(o) {
@@ -194,6 +195,7 @@ export function osmAuth(o) {
         state: state,
         code_challenge: pkce.code_challenge,
         code_challenge_method: pkce.code_challenge_method,
+        locale: o.locale || "",
       });
 
     if (o.singlepage) {


### PR DESCRIPTION
Closes #23

This PR allows you to specify the language of the login page. This unblocks [#3595](https://github.com/openstreetmap/iD/issues/3595)