### PR TITLE
trigger error if popup is closed prematurely

### DIFF
--- a/src/osm-auth.mjs
+++ b/src/osm-auth.mjs
@@ -228,6 +228,15 @@ export function osmAuth(o) {
         window.location = url;
       }
     } else {
+      var popupClosedWatcher = setInterval(function() {
+        if (popup.closed) {
+          var error = new Error('Popup was closed prematurely');
+          error.status = 'popup-closed';
+          callback(error);
+          window.clearInterval(popupClosedWatcher);
+          delete window.authComplete;
+        }
+      }, 1000);
       oauth.popupWindow = popup;
       popup.location = url;
     }
@@ -235,6 +244,7 @@ export function osmAuth(o) {
     // Called by a function in the redirect URL page, in the popup window. The
     // window closes itself.
     window.authComplete = function (url) {
+      clearTimeout(popupClosedWatcher);
       var params = utilStringQs(url.split('?')[1]);
       if (params.state !== state) {
         var error = new Error('Invalid state');


### PR DESCRIPTION
Currently, consumer applications don't get notified when the login process is aborted by closing the login popup window, causing these applications being stuck in a _waiting for login to complete_ state. As the login popup is often on a different domain than the application, there only way to find out that the popup was closed prematurely is by adding a watchdog loop which periodically checks if window is still open.

Fixes https://github.com/openstreetmap/iD/issues/10651