### PR TITLE
fix links to github issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _Breaking changes, which may affect downstream projects, are marked with a_ тЪая
 ##### 2025-Nov-04
 * Add better test for `localStorage` ([#144])
 
-[#144]: https://github.com/osmlab/osm_auth/issues/144
+[#144]: https://github.com/osmlab/osm-auth/issues/144
 
 
 ## 3.1.0
@@ -28,10 +28,10 @@ _Breaking changes, which may affect downstream projects, are marked with a_ тЪая
 * Detect if user tried to deny access in popup, notify BroadcastChannel ([#141], thanks [@ENT8R])
 * This project uses [`bun`](https://bun.com/) now for simpler developer tooling ([#142])
 
-[#139]: https://github.com/osmlab/osm_auth/issues/139
-[#140]: https://github.com/osmlab/osm_auth/issues/140
-[#141]: https://github.com/osmlab/osm_auth/issues/141
-[#142]: https://github.com/osmlab/osm_auth/issues/142
+[#139]: https://github.com/osmlab/osm-auth/issues/139
+[#140]: https://github.com/osmlab/osm-auth/issues/140
+[#141]: https://github.com/osmlab/osm-auth/issues/141
+[#142]: https://github.com/osmlab/osm-auth/issues/142
 [@tom-konda]: https://github.com/tom-konda
 [@ENT8R]: https://github.com/ENT8R
 


### PR DESCRIPTION
(partially a follow-up to #143, where I overlooked that the repo name also had a typo)