### PR TITLE
prevent crashes when running in node 26

### DIFF
--- a/src/osm-auth.mjs
+++ b/src/osm-auth.mjs
@@ -27,7 +27,7 @@ export function osmAuth(o) {
   // Note that accessing localStorage may throw a `SecurityError`, so wrap in a try/catch.
   var _store = null;
   try {
-    if (!('localStorage' in globalThis)) {
+    if (!('localStorage' in globalThis) || globalThis.localStorage === undefined) {
       throw new Error('No localStorage');
     }
     _store = globalThis.localStorage;


### PR DESCRIPTION
By testing if localStorage object is not undefined when it is there, fixes #151. See also https://github.com/openstreetmap/iD/pull/12401